### PR TITLE
feat(#2): JSON-driven SVG generator (Mode A injector) + tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # renderx-plugins-digital-assets
 Digital assets (SVGs, images, movies) for RenderX
+
+
+## JSON-driven SVG Generator
+Automates composition of integrated SVG elements from the JSON spec at `assets/plugin-architecture/plugin-integration-slides.json`.
+
+- Generate all slide element SVGs:
+  - `node scripts/generate-integrated-svgs.js --all`
+- Generate for a specific slide:
+  - `node scripts/generate-integrated-svgs.js --slide slide-01-manifest`
+- Filter to a specific element within a slide:
+  - `node scripts/generate-integrated-svgs.js --slide slide-01-manifest --element plugin-manifest`
+- Dry run and verbose:
+  - `node scripts/generate-integrated-svgs.js --slide slide-01-manifest --dry-run --verbose`
+
+Notes
+- Non-destructive: manages only the `<g id="sub-elements">` group in parent SVGs and ensures root namespaces.
+- Idempotent: running repeatedly yields no diff.
+- Added npm script: `npm run build:svgs`.
+
+Related tests
+- `tests/generator.injector.test.js` verifies href composition, injection, namespaces, and idempotency.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "build:svgs": "node scripts/generate-integrated-svgs.js --all"
   },
   "devDependencies": {
     "jest": "^29.7.0"

--- a/scripts/generate-integrated-svgs.js
+++ b/scripts/generate-integrated-svgs.js
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/* JSON-driven SVG generator (Mode A: injector) */
+const fs = require('fs');
+const path = require('path');
+const { generateForElement } = require('./lib/injector');
+
+const ROOT = process.cwd();
+const JSON_PATH = path.join(ROOT, 'assets', 'plugin-architecture', 'plugin-integration-slides.json');
+const ASSETS_ROOT = path.join(ROOT, 'assets', 'plugin-architecture');
+
+function parseArgs(argv) {
+  const args = { all: false, slide: null, element: null, dryRun: false, verbose: false };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--all') args.all = true;
+    else if (a === '--dry-run') args.dryRun = true;
+    else if (a === '--verbose' || a === '-v') args.verbose = true;
+    else if (a === '--slide') args.slide = argv[++i];
+    else if (a === '--element') args.element = argv[++i];
+  }
+  return args;
+}
+
+function loadSpec() {
+  const raw = fs.readFileSync(JSON_PATH, 'utf8');
+  return JSON.parse(raw);
+}
+
+function selectTargets(spec, args) {
+  let slides = spec.slides || [];
+  if (args.slide) slides = slides.filter(s => s.id === args.slide);
+  if (!args.all && !args.slide) {
+    // Default to slide-01 if unspecified
+    slides = slides.filter(s => s.id === 'slide-01-manifest');
+  }
+  const elements = [];
+  slides.forEach(s => {
+    (s.elements || []).forEach(el => {
+      if (args.element && el.id !== args.element) return;
+      if (el.svg && el.sub_elements && el.sub_elements.length) {
+        elements.push({ slideId: s.id, element: el });
+      }
+    });
+  });
+  return elements;
+}
+
+function ensureFile(filePath) {
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Parent SVG not found: ${filePath}`);
+  }
+}
+
+function run() {
+  const args = parseArgs(process.argv);
+  const spec = loadSpec();
+  const targets = selectTargets(spec, args);
+  if (!targets.length) {
+    console.error('No targets found. Use --all, --slide <id>, or ensure sub_elements exist.');
+    process.exit(1);
+  }
+
+  let changed = 0;
+  const summaries = [];
+
+  targets.forEach(({ slideId, element }) => {
+    const parentRel = element.svg; // e.g., slide-01-manifest/plugin-manifest.svg
+    const parentPath = path.join(ASSETS_ROOT, parentRel);
+    ensureFile(parentPath);
+
+    const orig = fs.readFileSync(parentPath, 'utf8');
+    const next = generateForElement(orig, element);
+
+    if (orig !== next) {
+      changed++;
+      if (!args.dryRun) fs.writeFileSync(parentPath, next, 'utf8');
+    }
+
+    if (args.verbose) {
+      summaries.push({ slideId, elementId: element.id, file: parentRel, updated: orig !== next });
+    }
+  });
+
+  if (args.verbose) {
+    console.log(JSON.stringify({ processed: targets.length, changed, details: summaries }, null, 2));
+  } else {
+    console.log(`Processed ${targets.length} elements; updated ${changed}.`);
+  }
+}
+
+if (require.main === module) {
+  try {
+    run();
+  } catch (err) {
+    console.error(err.message || String(err));
+    process.exit(1);
+  }
+}
+

--- a/scripts/lib/injector.js
+++ b/scripts/lib/injector.js
@@ -1,0 +1,64 @@
+/* JSON-driven SVG injector library (Mode A) */
+const SLIDE_PREFIX_RE = /^slide-\d{2}-[^/]+\//;
+
+function buildUseTags(subElements) {
+  return subElements
+    .filter(se => se && se.id && se.svg)
+    .map(se => {
+      const href = `${se.svg.replace(SLIDE_PREFIX_RE, '')}#${se.id}`;
+      const x = se.compose && typeof se.compose.x === 'number' ? se.compose.x : 0;
+      const y = se.compose && typeof se.compose.y === 'number' ? se.compose.y : 0;
+      return `  <use x="${x}" y="${y}" xlink:href="${href}"/>`;
+    })
+    .join('\n');
+}
+
+function ensureNamespaces(svgContent) {
+  // Ensure xmlns and xmlns:xlink on root <svg ...>
+  return svgContent.replace(/<svg(\s[^>]*)?>/i, (m, attrs = '') => {
+    const hasXmlns = /xmlns=/.test(m);
+    const hasXlink = /xmlns:xlink=/.test(m);
+    let updated = `<svg${attrs || ''}`;
+    if (!hasXmlns) updated += ' xmlns="http://www.w3.org/2000/svg"';
+    if (!hasXlink) updated += ' xmlns:xlink="http://www.w3.org/1999/xlink"';
+    updated += '>';
+    return updated;
+  });
+}
+
+function injectGroup(svgContent, inner) {
+  const groupStartRe = /<g\s+id=["']sub-elements["'][^>]*>/i;
+  const groupFullRe = /<g\s+id=["']sub-elements["'][^>]*>[\s\S]*?<\/g>/i;
+
+  if (groupFullRe.test(svgContent)) {
+    return svgContent.replace(groupFullRe, `<g id="sub-elements">\n${inner}\n</g>`);
+  }
+
+  if (groupStartRe.test(svgContent)) {
+    // Has start but no close (edge), normalize by closing
+    return svgContent.replace(groupStartRe, `<g id=\"sub-elements\">\n${inner}\n</g>`);
+  }
+
+  // Insert before closing </svg>
+  if (/<\/svg>/i.test(svgContent)) {
+    return svgContent.replace(/<\/svg>/i, `<!-- Composed from sub-elements -->\n<g id=\"sub-elements\">\n${inner}\n</g>\n</svg>`);
+  }
+
+  // Fallback: append group
+  return `${svgContent}\n<g id="sub-elements">\n${inner}\n</g>`;
+}
+
+function generateForElement(parentSvgContent, element /* from JSON */) {
+  const uses = buildUseTags(element.sub_elements || []);
+  let updated = ensureNamespaces(parentSvgContent);
+  updated = injectGroup(updated, uses);
+  return updated;
+}
+
+module.exports = {
+  buildUseTags,
+  ensureNamespaces,
+  injectGroup,
+  generateForElement,
+};
+

--- a/tests/generator.injector.test.js
+++ b/tests/generator.injector.test.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const path = require('path');
+const { generateForElement, buildUseTags } = require('../scripts/lib/injector');
+
+describe('Generator Injector (Mode A)', () => {
+  const jsonPath = path.join(__dirname, '../assets/plugin-architecture/plugin-integration-slides.json');
+  let spec;
+  beforeAll(() => {
+    spec = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+  });
+
+  test('buildUseTags generates expected hrefs for plugin-manifest sub-elements', () => {
+    const slide = spec.slides.find(s => s.id === 'slide-01-manifest');
+    const el = slide.elements.find(e => e.id === 'plugin-manifest');
+    const uses = buildUseTags(el.sub_elements);
+    expect(uses).toMatch(/xlink:href="plugin-manifest\/document-card.svg#document-card"/);
+    expect(uses).toMatch(/xlink:href="plugin-manifest\/json-braces.svg#json-braces"/);
+    expect(uses).toMatch(/xlink:href="plugin-manifest\/key-value-rows.svg#key-value-rows"/);
+    expect(uses).toMatch(/xlink:href="plugin-manifest\/generated-stamp.svg#generated-stamp"/);
+    expect(uses).toMatch(/xlink:href="plugin-manifest\/tabs.svg#tabs"/);
+  });
+
+  test('generateForElement injects <g id="sub-elements"> and namespaces; idempotent', () => {
+    const slide = spec.slides.find(s => s.id === 'slide-01-manifest');
+    const el = slide.elements.find(e => e.id === 'plugin-manifest');
+
+    const parent = '<svg width="420" height="140"><title>Plugin Manifest</title>\n<!-- decorations here --></svg>';
+    const out1 = generateForElement(parent, el);
+
+    // Namespaces ensured on root
+    expect(out1).toMatch(/<svg[^>]*xmlns="http:\/\/www.w3.org\/2000\/svg"/);
+    expect(out1).toMatch(/xmlns:xlink="http:\/\/www.w3.org\/1999\/xlink"/);
+
+    // Group and some expected uses
+    expect(out1).toMatch(/<g id="sub-elements">[\s\S]*?<\/g>/);
+    expect(out1).toMatch(/xlink:href="plugin-manifest\/document-card.svg#document-card"/);
+
+    // Idempotent
+    const out2 = generateForElement(out1, el);
+    expect(out2).toBe(out1);
+  });
+});
+


### PR DESCRIPTION
This PR implements the JSON-driven SVG generator for integrated element SVGs (Mode A: injector), addressing #2.

What’s included:
- scripts/generate-integrated-svgs.js CLI (no external deps)
  - Flags: --all, --slide <id>, --element <id>, --dry-run, --verbose
- scripts/lib/injector.js library with pure functions (namespaces, <g id="sub-elements"> injection, and <use> generation)
- New test: tests/generator.injector.test.js
  - Verifies href composition, group injection, namespace enforcement, and idempotency
- package.json: add npm script "build:svgs"

Why:
- Automates composition of parent SVGs from JSON spec
- Keeps output consistent with assets/plugin-architecture/plugin-integration-slides.json
- Aligns with existing tests like slide-driven-composition.validation.test.js and prevents drift

How to use:
- node scripts/generate-integrated-svgs.js --slide slide-01-manifest
- node scripts/generate-integrated-svgs.js --all

Notes:
- Non-destructive: only manages <g id="sub-elements"> block and ensures root namespaces
- Idempotent: running multiple times yields identical output

Closes #2.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author